### PR TITLE
Register twig function correctly

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,6 +47,7 @@ services:
         arguments: ['@service_container']
         tags:
             - { name: roger.twig.extension }
+            - { name: twig.extension }
     validator.twig_syntax:
         class: %validator.twig_syntax.class%
         arguments: ['@roger.twig']


### PR DESCRIPTION
The twig functions aren't registered beacause of missing line in services.yml.
