### PR TITLE
fixed fatal error getting full url if page not found in RogerRoutingExtension

### DIFF
--- a/Extensions/Twig/Extension/RogerRoutingExtension.php
+++ b/Extensions/Twig/Extension/RogerRoutingExtension.php
@@ -46,7 +46,12 @@ class RogerRoutingExtension extends \Twig_Extension
     {
         $page = $this->em->getRepository('TheodoRogerCmsBundle:Page')->findOneBySlug($slug);
 
-        return $this->generator->generate('page', array('slug' => $page->getFullSlug()), true);
+        if ($page)
+        {
+            return $this->generator->generate('page', array('slug' => $page->getFullSlug()), true);
+        }
+
+        return '';
     }
 
     public function getMediaUrl($name)


### PR DESCRIPTION
When you call page_url with a slug that doesn't exist in database, this will raise a fatal error.

The worst case is when you call it in a footer, you'll not probably notice it right now, specially when slugs are changed in production whereas they are not in dev.
